### PR TITLE
Use `ThreadPoolExecuter` from `concurrent.futures` instead of bare `Thread`

### DIFF
--- a/bank.py
+++ b/bank.py
@@ -233,7 +233,7 @@ class Bank(BaseClass):
 
         with ThreadPoolExecutor(thread_name_prefix="common_send_receive") as executor:
             for branch in self.branches:
-                branch_id = branch["_id"]
+                branch_id = branch["id"]
                 executor.submit(self._do_common_transfer, branch_id)
                 executor.submit(self._do_common_receive, branch_id)
 

--- a/commons.py
+++ b/commons.py
@@ -115,5 +115,5 @@ class BaseClass:
 
     def _id_to_index(self, bid: int):
         for i, branch in enumerate(self.branches):
-            if branch["_id"] == bid:
+            if branch["id"] == bid:
                 return i

--- a/commons.py
+++ b/commons.py
@@ -48,14 +48,14 @@ class KBHit:
             # Support normal-terminal reset at exit
             atexit.register(self.set_normal_term)
 
-    def set_normal_term(self):
+    def set_normal_term(self) -> None:
         """
         Resets to normal terminal.  On Windows this is a no-op.
         """
         if os.name != "nt":
             termios.tcsetattr(self.fd, termios.TCSAFLUSH, self.old_term)
 
-    def getch(self):
+    def getch(self) -> str:
         """
         Returns a keyboard character after kbhit() has been called.
             Should not be called in the same program as getarrow().
@@ -63,7 +63,7 @@ class KBHit:
 
         return msvcrt.getch().decode("utf-8") if os.name == "nt" else sys.stdin.read(1)
 
-    def getarrow(self):
+    def getarrow(self) -> int:
         """Returns an arrow-key code after kbhit() has been called. Codes are
         0 : up
         1 : right
@@ -83,7 +83,7 @@ class KBHit:
 
         return vals.index(ord(c.decode("utf-8")))
 
-    def kbhit(self):
+    def kbhit(self) -> bool:
         """
         Returns True if keyboard character was hit, False otherwise.
         """
@@ -101,7 +101,7 @@ class BaseClass:
 
     def _log(
         self, message, stdio: bool = True, in_file: bool = False, file_mode: str = "a"
-    ):
+    ) -> None:
         prefix = datetime.now().strftime("%Y-%m-%d:%H:%M:%S ")
 
         output_string = f"{prefix}{message}"
@@ -113,7 +113,7 @@ class BaseClass:
             with open(self.log_database, mode=file_mode) as f:
                 f.write(output_string + "\n")
 
-    def _id_to_index(self, bid: int):
+    def _id_to_index(self, bid: int) -> int:
         for i, branch in enumerate(self.branches):
             if branch["id"] == bid:
                 return i

--- a/inspector.py
+++ b/inspector.py
@@ -2,7 +2,7 @@ import pickle
 import socket
 from concurrent.futures import ThreadPoolExecutor
 from threading import Lock
-from typing import Any, List, Mapping
+from typing import Any, List, Mapping, NoReturn, Optional
 
 from bank import Bank
 from commons import BaseClass, Constants
@@ -23,7 +23,7 @@ class Inspector(BaseClass):
 
         self._log("INSPECTOR LOG\n", in_file=True, stdio=False, file_mode="w")
 
-    def connect_to_branches(self):
+    def connect_to_branches(self) -> None:
 
         self._log("Waiting for branches ...")
 
@@ -50,7 +50,7 @@ class Inspector(BaseClass):
             )
             self.branches[-1]["in_sock"].listen(1)
 
-    def get_messages(self, bid: int):
+    def get_messages(self, bid: int) -> NoReturn:
 
         bid = self._id_to_index(bid)
 
@@ -102,7 +102,9 @@ class Inspector(BaseClass):
 
                 self._log(log_message, in_file=True)
 
-    def find_transfer_message(self, message: Mapping[str, Any], remove: bool = True):
+    def find_transfer_message(
+        self, message: Mapping[str, Any], remove: bool = True
+    ) -> Optional[Mapping[str, Any]]:
 
         with self.lock:
             for i, prev_message in enumerate(self.received_messages):
@@ -114,8 +116,6 @@ class Inspector(BaseClass):
 
                     return self.received_messages.pop(i) if remove else prev_message
 
-        return False
-
-    def run(self):
+    def run(self) -> None:
         with ThreadPoolExecutor() as executor:
             executor.map(self.get_messages, range(Bank.n_branches))


### PR DESCRIPTION
1. Use `ThreadPoolExecuter` from `concurrent.futures` instead of bare `Thread`
2. Use context for lock variable to free lock automatically
3. Add return type hints